### PR TITLE
fix: next cache in docker

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -28,6 +28,8 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json .
 COPY --from=builder /app/next.config.js .
 
+RUN mkdir -p /app/.next/cache/images
+
 # Block crawlers for staging deployments
 RUN if [ -z "$PRODUCTION" ]; then mv -f public/robots.staging.txt public/robots.txt; \
   else rm -f public/robots.staging.txt; fi


### PR DESCRIPTION
Dans l'espoir de résoudre ceci observé sur le pod `app` de la preprod:

```shell
Failed to write image to cache 450lOW-aDZFyquVItV8pQceP9lPx8fSynE2M2hDuJ7M= [Error: EACCES: permission denied, mkdir '/app/.next/cache/images'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'mkdir',
  path: '/app/.next/cache/images'
}
```